### PR TITLE
extlb healthcheck maps to loopback.1 to hit nat rule

### DIFF
--- a/bootstrap_files/bootstrap.xml.template
+++ b/bootstrap_files/bootstrap.xml.template
@@ -729,7 +729,7 @@
                     <translated-address>loopback-probes</translated-address>
                   </dynamic-destination-translation>
                   <description>External GCP load balancer health checks to VM-Series untrust.</description>
-                  <to-interface>ethernet1/1</to-interface>
+                  <to-interface>loopback.1</to-interface>
                 </entry>
                 <entry name="health-check-intlb" uuid="7a44c635-556d-45ac-92e6-2c0f606ff2bb">
                   <to>


### PR DESCRIPTION
## Description

extlb healthcheck maps to loopback.1 to hit nat rule

## Motivation and Context

The current configuration on the PANW vm series does not map the extlb healthcheck correctly.
Due to the existence of loopback.1, the extlb heathcheck coming into ethernet1/1 will then be targeting loopback.1, which fails to match the NAT for healthcheck probes. 

With the current configuration, from GCP load balancer, both active and passive backends behind external load balancer will show health check as failed.

## How Has This Been Tested?

Have followed the steps in README.md to apply the new configuration. Both internal and external load balancer will behave correctlty with active vm series showing healthy and forwarding traffic.

## Screenshots (if appropriate)

![image](https://github.com/PaloAltoNetworks/google-cloud-vmseries-ha-tutorial/assets/109029444/e08d9995-e428-4aa9-b088-be162d7530ac)


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
