### PR TITLE
 Update bootstrap template path in vmseries.tf

### DIFF
--- a/vmseries.tf
+++ b/vmseries.tf
@@ -62,7 +62,7 @@ data "google_compute_subnetwork" "ha2" {
 # Modify bootstrap.xml to reflect the VPC networks.
 data "template_file" "bootstrap_xml" {
   for_each = local.vmseries_vms
-  template = file("bootstrap_files/bootstrap.xml.template")
+  template = file("${path.module}/bootstrap_files/bootstrap.xml.template")
 
   vars = {
     external_lb_ip            = google_compute_address.external_nat_ip.address


### PR DESCRIPTION
This PR updates the vmseries.tf file to correct the path for the bootstrap template file used by the template_file data resource. The change ensures that the correct relative path is used when referencing the bootstrap.xml.template file, improving the module's portability and preventing potential issues related to incorrect file paths.

## Description

This PR updates the vmseries.tf file to correct the path for the bootstrap template file used by the template_file data resource. The change ensures that the correct relative path is used when referencing the bootstrap.xml.template file, improving the module's portability and preventing potential issues related to incorrect file paths.

## Motivation and Context

This change is required to ensure the Terraform module functions correctly in different environments by accurately referencing the bootstrap template file. Incorrect file paths can lead to errors during the deployment process, and this update addresses that issue.

I was not able to execute this module from different directories so thought to update it.

## How Has This Been Tested?

The change was tested in a local development environment by running the Terraform configuration after updating the path. No errors were encountered, and the module successfully referenced the bootstrap.xml.template file, confirming the fix.

## Screenshots (if appropriate)


## Types of changes


- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes if appropriate.
- [ x] All new and existing tests passed.
