### PR TITLE
Update bootstrap template path in vmseries.tf

### DIFF
--- a/vmseries.tf
+++ b/vmseries.tf
@@ -81,7 +81,7 @@ data "template_file" "bootstrap_xml" {
 
 resource "local_file" "bootstrap_xml" {
   for_each = local.vmseries_vms
-  filename = "tmp/bootstrap-${each.key}"
+  filename = "${path.module}/tmp/bootstrap-${each.key}"
   content  = data.template_file.bootstrap_xml[each.key].rendered
 }
 
@@ -102,9 +102,9 @@ module "bootstrap" {
   service_account = module.iam_service_account.email
 
   files = {
-    "bootstrap_files/init-cfg.txt.sample" = "config/init-cfg.txt"
-    "tmp/bootstrap-${each.key}"           = "config/bootstrap.xml"
-    "bootstrap_files/authcodes"           = "license/authcodes"
+    "${path.module}/bootstrap_files/init-cfg.txt.sample" = "config/init-cfg.txt"
+    "${path.module}/tmp/bootstrap-${each.key}"           = "config/bootstrap.xml"
+    "${path.module}/bootstrap_files/authcodes"           = "license/authcodes"
   }
 
   depends_on = [


### PR DESCRIPTION
This PR is following my previous PR in which i missed to add all relevant paths to enhance its usability and it updates the vmseries.tf file to correct the path for the bootstrap template file used by the template_file data resource. The change ensures that the correct relative path is used when referencing the bootstrap.xml.template file, improving the module's portability and preventing potential issues related to incorrect file paths.

## Description

This PR updates the vmseries.tf file to correct the path for the bootstrap template file used by the template_file data resource. The change ensures that the correct relative path is used when referencing the bootstrap.xml.template file, improving the module's portability and preventing potential issues related to incorrect file paths.

## Motivation and Context

This change is required to ensure the Terraform module functions correctly in different environments by accurately referencing the bootstrap template file. Incorrect file paths can lead to errors during the deployment process, and this update addresses that issue.

I was not able to execute this module from different directories so thought to update it.

## How Has This Been Tested?

The change was tested in a local development environment by running the Terraform configuration after updating the path. No errors were encountered, and the module successfully referenced the bootstrap.xml.template file, confirming the fix.

## Screenshots (if appropriate)


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes if appropriate.
- [x ] All new and existing tests passed.
